### PR TITLE
feat(ci): add PR title validator workflow

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -1,0 +1,17 @@
+{
+  "LABEL": {
+    "success": "✅ Valid PR Title",
+    "failure": "❌ Invalid PR Title"
+  },
+  "CHECKS": {
+    "prefixes": ["feat", "fix", "docs", "style", "refactor", "perf", "test", "build", "ci", "chore", "revert"],
+    "regexp": "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\\(.+\\))?!?: .{1,100}$",
+    "regexpFlags": "i",
+    "ignoreLabels": ["skip-title-check", "dependencies"]
+  },
+  "MESSAGES": {
+    "success": "PR title follows the conventional commit format! 🎉",
+    "failure": "PR title must follow conventional commit format:\n\n**Format:** `<type>(<scope>): <description>`\n\n**Types:** feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert\n\n**Examples:**\n- `feat: add new feature`\n- `fix: resolve bug in parser`\n- `docs: update README`\n- `feat(api): add new endpoint`\n- `fix(ui)!: breaking change in button component`",
+    "notice": ""
+  }
+}

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,50 @@
+name: PR Title Checker
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-pr-title:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title
+        uses: thehanimo/pr-title-checker@v1.4.2
+        id: pr_title_check
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pass_on_octokit_error: false
+          configuration_path: .github/pr-title-checker-config.json
+
+      - name: Display PR title validation result
+        if: always()
+        run: |
+          echo "PR Title Check Result: ${{ steps.pr_title_check.outcome }}"
+          echo "PR Title: ${{ github.event.pull_request.title }}"
+
+      - name: Comment on PR with validation result
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '❌ **PR Title Validation Failed**\n\nYour PR title does not match the required format. Please update your PR title to follow the project conventions.\n\nCurrent title: `${{ github.event.pull_request.title }}`'
+            })
+
+      - name: Comment on PR with success
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '✅ **PR Title Validation Passed**\n\nYour PR title follows the required format. Thank you!'
+            })


### PR DESCRIPTION
Add GitHub Actions workflow to validate PR titles using pr-title-checker. The workflow validates titles against conventional commit format and provides output results that can be used in subsequent steps.

Features:
- Validates PR titles on open, edit, sync, and reopen events
- Uses conventional commit format (feat, fix, docs, etc.)
- Provides success/failure comments on PRs
- Configurable via .github/pr-title-checker-config.json
- Outputs validation results for further processing

The configuration supports:
- Multiple commit types (feat, fix, docs, style, refactor, etc.)
- Optional scope in parentheses
- Breaking change indicator (!)
- Skip validation with labels (skip-title-check, dependencies)