### PR TITLE
feat: Auto-download themes from repository when missing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ image = "0.25"
 base64 = "0.22"
 ureq = "2.10"
 regex = "1.10"
+git2 = "0.19"
 
 [lib]
 name = "genkan"


### PR DESCRIPTION
Implements automatic theme downloading during build process. When a theme is not found locally, the system will automatically clone the Genkan repository and extract the requested theme to the local themes directory.

Changes:
- Add git2 dependency for Git repository cloning
- Add download_theme() function to clone and extract themes
- Add copy_dir_recursive() helper for directory copying
- Modify find_theme_path() to attempt download if theme not found locally
- Add DEFAULT_THEME_REPO constant for theme source URL

This resolves issue #1 by implementing option 2: downloading only the selected theme when needed during build, rather than downloading all themes during init.

Usage:
1. User configures theme.name = "simple" in config.toml
2. User runs genkan build
3. If themes/simple/ doesn't exist, it's auto-downloaded
4. Build continues with the downloaded theme