### PR TITLE
feat(ci): enhance Rust checks and add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## Description
+
+<!-- Provide a brief description of the changes in this PR -->
+
+## Type of Change
+
+<!-- Mark the relevant option with an "x" -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Other (please describe):
+
+## Checklist
+
+Before submitting your PR, please ensure you have completed the following:
+
+- [ ] I have run `cargo test` and all tests pass
+- [ ] I have run `cargo fmt --all -- --check` and there are no formatting issues
+- [ ] I have run `cargo clippy --all-targets --all-features -- -D warnings` and resolved all warnings
+- [ ] My code follows the project's style guidelines
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have updated the documentation accordingly (if applicable)
+
+## Additional Context
+
+<!-- Add any other context about the PR here -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,10 @@ jobs:
           components: rustfmt, clippy
 
       - name: Check formatting
-        run: cargo fmt -- --check
+        run: cargo fmt --all -- --check
 
       - name: Run clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
   security:
     name: Security audit


### PR DESCRIPTION
- Update CI workflow to use comprehensive Rust checks:
  - cargo fmt --all -- --check for formatting
  - cargo clippy --all-targets --all-features -- -D warnings for linting
- Add PR template with checklist for required Rust checks
- Ensure contributors run all checks before submitting PRs