### PR TITLE
fix: use target-specific strip for aarch64 cross-compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,8 +89,18 @@ jobs:
         if: ${{ !matrix.use_cross }}
         run: cargo build --release --target ${{ matrix.target }}
 
-      - name: Strip binary (Linux and macOS)
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+      - name: Install cross-compilation tools for aarch64
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y binutils-aarch64-linux-gnu
+
+      - name: Strip binary (Linux aarch64)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: aarch64-linux-gnu-strip target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
+
+      - name: Strip binary (Linux x86_64 and macOS)
+        if: (matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64-unknown-linux-gnu') || matrix.os == 'macos-latest'
         run: strip target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
 
       - name: Create tarball (Unix)


### PR DESCRIPTION
## Description

The CI was failing because the native strip command on x86_64 Ubuntu runners cannot recognize aarch64 binary format. This commit fixes the issue by:

- Installing binutils-aarch64-linux-gnu for cross-compilation
- Using aarch64-linux-gnu-strip for aarch64 binaries
- Keeping native strip for x86_64 and macOS targets

Fixes the error: "strip: Unable to recognise the format of the input file"

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

Before submitting your PR, please ensure you have completed the following:

- [ ] I have run `cargo test` and all tests pass
- [ ] I have run `cargo fmt --all -- --check` and there are no formatting issues
- [ ] I have run `cargo clippy --all-targets --all-features -- -D warnings` and resolved all warnings
- [ ] My code follows the project's style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A