### PR TITLE
fix: only show PR title validation message once on PR creation

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -42,7 +42,7 @@ jobs:
             })
 
       - name: Comment on PR with success
-        if: success()
+        if: success() && github.event.action == 'opened'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Previously, the validation success message was displayed on every PR event (opened, edited, synchronize, reopened), causing multiple redundant messages when pushing commits. Now it only shows once when the PR is first opened.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

Before submitting your PR, please ensure you have completed the following:

- [ ] I have run `cargo test` and all tests pass
- [ ] I have run `cargo fmt --all -- --check` and there are no formatting issues
- [ ] I have run `cargo clippy --all-targets --all-features -- -D warnings` and resolved all warnings
- [ ] My code follows the project's style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

N/A